### PR TITLE
Declare idx as a private in calham.c

### DIFF
--- a/src/calham.c
+++ b/src/calham.c
@@ -22,7 +22,7 @@ double CalculateHamiltonian(const double ip, int *eleIdx, const int *eleCfg,
   /* GreenFunc1: NQPFull, GreenFunc2: NQPFull+2*Nsize */
 
 #pragma omp parallel default(shared)\
-  private(myEleIdx,myEleNum,myProjCntNew,myBuffer,myEnergy)\
+  private(myEleIdx,myEleNum,myProjCntNew,myBuffer,myEnergy,idx)\
   reduction(+:e)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);


### PR DESCRIPTION
I don't know how #pragma loop directive works with other compiler, but at least with Cray compiler this code makes wrong behavior without declaring variable idx as a private.
